### PR TITLE
Remove failed feeds

### DIFF
--- a/frontend-feeds.opml
+++ b/frontend-feeds.opml
@@ -9,249 +9,202 @@
     <ownerEmail>holler at paulirish dot com</ownerEmail>
   </head>
   <body>
-    <outline text='frontend-webapps' title='frontend-webapps'>
-      <outline htmlUrl='https://addyosmani.com/' text='AddyOsmani.com' title='AddyOsmani.com' type='rss' xmlUrl='https://addyosmani.com/rss.xml' />
-      <outline htmlUrl='http://blog.nodejitsu.com/' text='blog.nodejitsu.com' title='blog.nodejitsu.com' type='rss' xmlUrl='http://blog.nodejitsu.com/feed.xml' />
-      <outline htmlUrl='http://blog.pamelafox.org/' text="pamela fox's blog" title="pamela fox's blog" type='rss' xmlUrl='http://blog.pamelafox.org/feeds/posts/default' />
-      <outline htmlUrl='http://cordova.apache.org/rss.xml' text='Apache Cordova' title='Apache Cordova' type='rss' xmlUrl='http://cordova.apache.org/rss.xml' />
-      <outline htmlUrl='http://kilon.org/blog' text='Simple Thoughts' title='Simple Thoughts' type='rss' xmlUrl='http://kilon.org/blog/feed/' />
-      <outline htmlUrl='http://labs.ft.com' text='FT LabsFT Labs' title='FT LabsFT Labs' type='rss' xmlUrl='http://labs.ft.com/feed/' />
-      <outline htmlUrl='http://phonegap.com/' text='PhoneGap' title='PhoneGap' type='rss' xmlUrl='http://phonegap.com/rss.xml' />
-      <outline htmlUrl='http://pipes.yahoo.com/pipes/pipe.info?_id=647030be6aceb6d005c3775a1c19401c' text='HTML5Rocks' title='HTML5Rocks' type='rss' xmlUrl='http://feeds.feedburner.com/html5rocks' />
-      <outline htmlUrl='http://rmurphey.com/' text='Rebecca Murphey' title='Rebecca Murphey' type='rss' xmlUrl='http://rmurphey.com/atom.xml' />
-      <outline htmlUrl='http://smus.com' text='Boris Smus' title='Boris Smus' type='rss' xmlUrl='http://feeds.feedburner.com/smuscom' />
-      <outline htmlUrl='https://bocoup.com' text='Bocoup Blog' title='Bocoup Blog' type='rss' xmlUrl='http://feeds.feedburner.com/bocoup' />
-      <outline htmlUrl='https://lostechies.com' text='ThoughtStream.new' title='ThoughtStream.new' type='rss' xmlUrl='http://feeds.feedburner.com/LosTechies' />
-      <outline htmlUrl='http://tjholowaychuk.com/' text='TJ Holowaychuk' title='TJ Holowaychuk' type='rss' xmlUrl='http://tjholowaychuk.com/rss' />
-      <outline htmlUrl='http://www.tjholowaychuk.com/blog/' text='Blog - TJ Holowaychuk' title='Blog - TJ Holowaychuk' type='rss' xmlUrl='http://www.tjholowaychuk.com/blog?format=RSS'/>
-      <outline htmlUrl='http://tomdale.net' text='Tom Dale' title='Tom Dale' type='rss' xmlUrl='http://tomdale.net/feed/' />
-      <outline htmlUrl='https://www.sitepen.com/blog' text='SitePen Blog' title='SitePen Blog' type='rss' xmlUrl='http://www.sitepen.com/blog/feed/' />
+    <outline text="frontend-webapps" title="frontend-webapps">
+      <outline text="AddyOsmani.com" title="AddyOsmani.com" type="rss" xmlUrl="https://addyosmani.com/rss.xml" htmlUrl="http://addyosmani.com/"/>
+      <outline text="blog.nodejitsu.com" title="blog.nodejitsu.com" type="rss" xmlUrl="http://blog.nodejitsu.com/feed.xml" htmlUrl="http://blog.nodejitsu.com/"/>
+      <outline text="pamela fox's blog" title="pamela fox's blog" type="rss" xmlUrl="http://blog.pamelafox.org/feeds/posts/default" htmlUrl="http://blog.pamelafox.org/"/>
+      <outline text="Simple Thoughts" title="Simple Thoughts" type="rss" xmlUrl="http://kilon.org/blog/feed/" htmlUrl="http://kilon.org/blog"/>
+      <outline text="HTML5Rocks" title="HTML5Rocks" type="rss" xmlUrl="http://feeds.feedburner.com/html5rocks" htmlUrl="http://pipes.yahoo.com/pipes/pipe.info?_id=647030be6aceb6d005c3775a1c19401c"/>
+      <outline text="Boris Smus" title="Boris Smus" type="rss" xmlUrl="http://feeds.feedburner.com/smuscom" htmlUrl="http://smus.com/"/>
+      <outline text="Bocoup Blog" title="Bocoup Blog" type="rss" xmlUrl="http://feeds.feedburner.com/bocoup" htmlUrl="http://bocoup.com/weblog/feed"/>
+      <outline text="ThoughtStream.new" title="ThoughtStream.new" type="rss" xmlUrl="http://feeds.feedburner.com/LosTechies" htmlUrl="http://lostechies.com/"/>
+      <outline text="SitePen Blog" title="SitePen Blog" type="rss" xmlUrl="http://www.sitepen.com/blog/feed/" htmlUrl="http://www.sitepen.com/blog"/>
     </outline>
-    <outline text='frontend' title='frontend'>
-      <outline htmlUrl='http://aerotwist.com/blog/feed/' text='Aerotwist Blog' title='Aerotwist Blog' type='rss' xmlUrl='http://aerotwist.com/blog/feed/' />
-      <outline htmlUrl='http://alexsexton.com' text='Alex Sexton' title='Alex Sexton' type='rss' xmlUrl='http://alexsexton.com/?feed=rss2' />
-      <outline htmlUrl='http://alistapart.com' text='A List Apart' title='A List Apart' type='rss' xmlUrl='http://www.alistapart.com/rss.xml' />
-      <outline htmlUrl='http://allyoucanleet.com/' text='All You Can 1337' title='All You Can 1337' type='rss' xmlUrl='http://allyoucanleet.com/rss' />
-      <outline htmlUrl='http://alxgbsn.co.uk/' text='Alex Gibson' title='Alex Gibson' type='rss' xmlUrl='http://alxgbsn.co.uk/feed/' />
-      <outline htmlUrl='http://angular-tips.com/' text='Angular Tips' title='Angular Tips' type='rss' xmlUrl='http://angular-tips.com/atom.xml' />
-      <outline htmlUrl='http://angularjs.blogspot.com/' text='AngularJS' title='AngularJS' type='rss' xmlUrl='http://blog.angularjs.org/feeds/posts/default' />
-      <outline htmlUrl='http://antimatter15.com/wp' text='antimatter15' title='antimatter15' type='rss' xmlUrl='http://antimatter15.com/wp/feed/' />
-      <outline htmlUrl='http://ariya.ofilabs.com' text="don't code today" title="don't code today" type='rss' xmlUrl='http://ariya.ofilabs.com/feed' />
-      <outline htmlUrl='http://badassjs.com/' text='Badass JavaScript' title='Badass JavaScript' type='rss' xmlUrl='http://rss.badassjs.com/' />
-      <outline htmlUrl='http://benfrain.com' text='Ben Frain' title='Ben Frain' type='rss' xmlUrl='http://benfrain.com/feed/' />
-      <outline htmlUrl='http://bensmithett.com/' text='Ben Smithett' title='Ben Smithett' type='rss' xmlUrl='http://bensmithett.com/feed.xml' />
-      <outline htmlUrl='http://blog.atom.io' text='Atom Blog' title='Atom Blog' type='rss' xmlUrl='http://blog.atom.io/feed.xml' />
-      <outline htmlUrl='http://blog.brackets.io' text='Brackets Blog' title='Brackets Blog' type='rss' xmlUrl='http://blog.brackets.io/feed/' />
-      <outline htmlUrl='http://blog.cloudfour.com' text='Cloud Four Blog' title='Cloud Four Blog' type='rss' xmlUrl='http://blog.cloudfour.com/feed/' />
-      <outline htmlUrl='http://blog.couchdb.org' text='CouchDB Blog' title='CouchDB Blog' type='rss' xmlUrl='http://blog.couchdb.org/feed/' />
-      <outline htmlUrl='http://blog.davebalmer.com/' text='Dave Balmer' title='Dave Balmer' type='rss' xmlUrl='http://blog.davebalmer.com/rss/' />
-      <outline htmlUrl='http://blog.getbootstrap.com/' text='Bootstrap Blog' title='Bootstrap Blog' type='rss' xmlUrl='http://blog.getbootstrap.com/feed.xml' />
-      <outline htmlUrl='http://blog.jquery.com' text='jQuery Blog' title='jQuery Blog' type='rss' xmlUrl='http://feeds.feedburner.com/jquery/' />
-      <outline htmlUrl='http://blog.keithcirkel.co.uk/' text='Keith Cirkel' title='Keith Cirkel' type='rss' xmlUrl='http://blog.keithcirkel.co.uk/rss/' />
-      <outline htmlUrl='http://blog.npmjs.org/' text='The npm Blog' title='The npm Blog' type='rss' xmlUrl='http://blog.npmjs.org/rss' />
-      <outline htmlUrl='http://blog.patrickmeenan.com/' text='Performance Matters' title='Performance Matters' type='rss' xmlUrl='http://blog.patrickmeenan.com/feeds/posts/default' />
-      <outline htmlUrl='http://blog.reybango.com' text='Rey Bango' title='Rey Bango' type='rss' xmlUrl='http://blog.reybango.com/feed/' />
-      <outline htmlUrl='http://blog.vjeux.com' text='Vjeux' title='Vjeux' type='rss' xmlUrl='http://blog.vjeux.com/feed' />
-      <outline htmlUrl='http://blog.tojicode.com/' text='TojiCode' title='TojiCode' type='rss' xmlUrl='http://blog.tojicode.com/feeds/posts/default' />
-      <outline htmlUrl='http://blog.xk72.com/' text='Karl von Randow' title='Karl von Randow' type='rss' xmlUrl='http://xk72.com/blog/feed/' />
-      <outline htmlUrl='http://blog.zkoss.org' text='The ZK Blog' title='The ZK Blog' type='rss' xmlUrl='http://blog.zkoss.org/index.php/feed/' />
-      <outline htmlUrl='http://blogs.msdn.com/b/typescript/' text='TypeScript' title='TypeScript' type='rss' xmlUrl='http://blogs.msdn.com/b/typescript/rss.aspx' />
-      <outline htmlUrl='http://bradfrost.com' text='Brad Frost »' title='Brad Frost »' type='rss' xmlUrl='http://feeds.feedburner.com/brad-frosts-blog' />
-      <outline htmlUrl='http://code.tutsplus.com' text='Nettuts+' title='Nettuts+' type='rss' xmlUrl='http://net.tutsplus.com/feed/' />
-      <outline htmlUrl='http://coenraets.org/blog' text='Christophe Coenraets' title='Christophe Coenraets' type='rss' xmlUrl='http://coenraets.org/blog/feed/' />
-      <outline htmlUrl='http://cordova.apache.org/rss.xml' text='Apache Cordova' title='Apache Cordova' type='rss' xmlUrl='http://cordova.apache.org/rss.xml' />
-      <outline htmlUrl='http://cubiq.org' text="Matteo Spinelli's Cubiq.org" title="Matteo Spinelli's Cubiq.org" type='rss' xmlUrl='http://cubiq.org/feed' />
-      <outline htmlUrl='http://dailyjs.com/' text='DailyJS' title='DailyJS' type='rss' xmlUrl='http://feeds.feedburner.com/dailyjs' />
-      <outline htmlUrl='http://dapperdeveloper.com' text='The Dapper Developer' title='The Dapper Developer' type='rss' xmlUrl='http://dapperdeveloper.com/feed/' />
-      <outline htmlUrl='http://daverupert.com' text='daverupert.com' title='daverupert.com' type='rss' xmlUrl='http://daverupert.com/atom.xml' />
-      <outline htmlUrl='http://davidwalsh.name' text='David Walsh Blog' title='David Walsh Blog' type='rss' xmlUrl='http://feeds.feedburner.com/Bludice' />
-      <outline htmlUrl='http://devgirl.org' text="Devgirl's Weblog" title="Devgirl's Weblog" type='rss' xmlUrl='http://devgirl.org/feed/' />
-      <outline htmlUrl='http://dilbert.com' text='Dilbert Daily Strip' title='Dilbert Daily Strip' type='rss' xmlUrl='http://feeds.feedburner.com/DilbertDailyStrip' />
-      <outline htmlUrl='http://distilledhype.net' text='The Distilled Hype Feed' title='The Distilled Hype Feed' type='rss' xmlUrl='http://distilledhype.com/feed' />
-      <outline htmlUrl='http://ecmanaut.blogspot.com/' text='ecmanaut' title='ecmanaut' type='rss' xmlUrl='http://feeds.feedburner.com/ecmanaut' />
-      <outline htmlUrl='http://ejohn.org' text='John Resig' title='John Resig' type='rss' xmlUrl='http://feeds.feedburner.com/JohnResig' />
-      <outline htmlUrl='http://emberjs.com/blog' text='Ember Blog' title='Ember Blog' type='rss' xmlUrl='http://emberjs.com/blog/feed.xml' />
-      <outline htmlUrl='http://eligrey.com/blog' text='Eli Grey' title='Eli Grey' type='rss' xmlUrl='http://feeds.feedburner.com/eligrey' />
-      <outline htmlUrl='http://eng.wealthfront.com/' text='Wealthfront Engineering' title='Wealthfront Engineering' type='rss' xmlUrl='http://eng.wealthfront.com/feeds/posts/default' />
-      <outline htmlUrl='http://felixge.de' text='Felix Geisendörfer' title='Felix Geisendörfer' type='rss' xmlUrl='http://feeds.feedburner.com/felixge' />
-      <outline htmlUrl='http://filamentgroup.com/lab/' text='Filament Group, Inc: Lab' title='Filament Group, Inc: Lab' type='rss' xmlUrl='http://www.filamentgroup.com/lab/atom/' />
-      <outline htmlUrl='http://erik.eae.net' text='arv-o-matic: The Weblog of Erik Arvidsson' title='arv-o-matic: The Weblog of Erik Arvidsson' type='rss' xmlUrl='http://erik.eae.net/feed/atom/' />
-      <outline htmlUrl='http://fitzgeraldnick.com/weblog/' text='Nick Fitzgerald' title='Nick Fitzgerald' type='rss' xmlUrl='http://fitzgeraldnick.com/weblog/feeds/latest-atom/' />
-      <outline htmlUrl='http://fusiongrokker.com/' text='FusionGrokker' title='FusionGrokker' type='rss' xmlUrl='http://feeds2.feedburner.com/FusionGrokker/' />
-      <outline htmlUrl='http://githubengineering.com/' text='GitHub Engineering' title='GitHub Engineering' type='rss' xmlUrl='http://githubengineering.com/atom.xml' />
-      <outline htmlUrl='http://googleblog.blogspot.com/' text='The Official Google Blog' title='The Official Google Blog' type='rss' xmlUrl='http://googleblog.blogspot.com/feeds/posts/default?alt=rss' />
-      <outline htmlUrl='http://googledevelopers.blogspot.com/' text='Google Developers Blog' title='Google Developers Blog' type='rss' xmlUrl='http://code.google.com/feeds/updates.xml' />
-      <outline htmlUrl='http://googlewebmastercentral.blogspot.com/' text='Google Webmaster Central Blog' title='Google Webmaster Central Blog' type='rss' xmlUrl='http://feeds.feedburner.com/blogspot/amDG' />
-      <outline htmlUrl='http://gruntjs.com' text='Grunt Blog Feed' title='Grunt Blog Feed' type='rss' xmlUrl='http://gruntjs.com/rss' />
-      <outline htmlUrl='http://h5bp.net/' text='HTML5Boilerplate' title='HTML5Boilerplate' type='rss' xmlUrl='http://h5bp.net/rss' />
-      <outline htmlUrl='http://html5doctor.com' text='HTML5 Doctor' title='HTML5 Doctor' type='rss' xmlUrl='http://feeds.feedburner.com/html5doctor' />
-      <outline htmlUrl='http://htmlcssjavascript.com' text='HTML + CSS + JavaScript' title='HTML + CSS + JavaScript' type='rss' xmlUrl='http://feeds.feedburner.com/HtmlCssJavascript' />
-      <outline htmlUrl='http://inspectelement.com' text='Inspect Element' title='Inspect Element' type='rss' xmlUrl='http://feeds.feedburner.com/inspectelement' />
-      <outline htmlUrl='http://jakearchibald.com/' text="Jake Archibald's Blog" title="Jake Archibald's Blog" type='rss' xmlUrl='http://jakearchibald.com/posts.rss' />
-      <outline htmlUrl='http://james.padolsey.com' text='James Padolsey' title='James Padolsey' type='rss' xmlUrl='http://feeds.feedburner.com/JamesPadolsey' />
-      <outline htmlUrl='http://japhr.blogspot.com/' text='japh(r) by Chris Strom' title='japh(r) by Chris Strom' type='rss' xmlUrl='http://japhr.blogspot.com/feeds/posts/default' />
-      <outline htmlUrl='http://javascriptweekly.com/' text='JavaScript Weekly' title='JavaScript Weekly' type='rss' xmlUrl='http://javascriptweekly.com/rss' />
-      <outline htmlUrl='http://joshnh.com' text='Joshua Hibbert' title='Joshua Hibbert' type='rss' xmlUrl='http://feeds.feedburner.com/joshnh' />
-      <outline htmlUrl='http://jsrocks.org' text='JS Rocks' title='JS Rocks' type='rss' xmlUrl='http://es6rocks.com/rss.xml' />
-      <outline htmlUrl='http://lea.verou.me' text='Lea Verou' title='Lea Verou' type='rss' xmlUrl='http://feeds2.feedburner.com/leaverou' />
-      <outline htmlUrl='http://learningthreejs.com/' text='Learning Three.js' title='Learning Three.js' type='rss' xmlUrl='http://feeds.feedburner.com/LearningThreejs' />
-      <outline htmlUrl='http://learningwebgl.com/blog' text='Learning WebGL' title='Learning WebGL' type='rss' xmlUrl='http://learningwebgl.com/blog/?feed=rss2' />
-      <outline htmlUrl='http://loige.co/' text='Loige' title='Loige' type='rss' xmlUrl='http://loige.com/rss/' />
-      <outline htmlUrl='http://marcgrabanski.com' text='Mark Grabanski' title='Mark Grabanski' type='rss' xmlUrl='http://feeds.feedburner.com/allTrades' />
-      <outline htmlUrl='http://marcus-experiments.tumblr.com/' text='Experiments' title='Experiments' type='rss' xmlUrl='http://marcus-experiments.tumblr.com/rss' />
-      <outline htmlUrl='http://markdotto.com/' text='Mark Otto' title='Mark Otto' type='rss' xmlUrl='http://feeds.feedburner.com/mdo' />
-      <outline htmlUrl='http://meyerweb.com/eric/thoughts' text='Thoughts From Eric' title='Thoughts From Eric' type='rss' xmlUrl='http://meyerweb.com/eric/thoughts/rss2/summary' />
-      <outline htmlUrl='http://mir.aculo.us' text='mir.aculo.us' title='mir.aculo.us' type='rss' xmlUrl='http://feeds.feedburner.com/miraculous' />
-      <outline htmlUrl='http://mircozeiss.com//' text='Mirco Zeiss' title='Mirco Zeiss' type='rss' xmlUrl='http://mircozeiss.com/atom.xml' />
-      <outline htmlUrl='http://ndesign-studio.com' text='N.Design Studio | Design Blog &amp; Portfolio' title='N.Design Studio | Design Blog &amp; Portfolio' type='rss' xmlUrl='http://ndesign-studio.com/feed' />
-      <outline htmlUrl='http://nicolasgallagher.com' text='Nicolas Gallagher' title='Nicolas Gallagher' type='rss' xmlUrl='http://nicolasgallagher.com/category/code/feed/' />
-      <outline htmlUrl='http://npmawesome.com' text='npmawesome.com' title='npmawesome.com' type='rss' xmlUrl='http://feeds.feedburner.com/npmawesome' />
-      <outline htmlUrl='http://osvaldas.info/' text='Osvaldas Valutis' title='Osvaldas Valutis' type='rss' xmlUrl='http://osvaldas.info/rss/blog' />
-      <outline htmlUrl='http://paulaborowska.com' text='Paula Borowska' title='Paula Borowska' type='rss' xmlUrl='http://paulaborowska.com/feed/' />
-      <outline htmlUrl='http://paulrouget.com' text='Paul Rouget' title='Paul Rouget' type='rss' xmlUrl='http://paulrouget.com/index.xml' />
-      <outline htmlUrl='http://paulirish.com/' text='Paul Irish' title='Paul Irish' type='rss' xmlUrl='http://feeds.feedburner.com/paul-irish' />
-      <outline htmlUrl='http://phajdan-jr.blogspot.com/' text="Paweł Hajdan's Dev Blog" title="Paweł Hajdan's Dev Blog" type='rss' xmlUrl='http://feeds.feedburner.com/PawelHajdansDevBlog' />
-      <outline htmlUrl='http://phonegap.com/' text='PhoneGap' title='PhoneGap' type='rss' xmlUrl='http://phonegap.com/rss.xml' />
-      <outline htmlUrl='http://pmuellr.blogspot.com/' text='pmuellr' title='pmuellr' type='rss' xmlUrl='http://pmuellr.blogspot.com/feeds/posts/default' />
-      <outline htmlUrl='http://remotesynthesis.com/' text='Remote Synthesis' title='Remote Synthesis' type='rss' xmlUrl='http://www.remotesynthesis.com/blog/rss.cfm?mode=full' />
-      <outline htmlUrl='http://robertnyman.com' text="Robert's talk" title="Robert's talk" type='rss' xmlUrl='http://feeds.feedburner.com/robertnyman' />
-      <outline htmlUrl='http://rumproarious.com/' text='Alex Kessinger - engineer, creator, collector' title='Alex Kessinger - engineer, creator, collector' type='rss' xmlUrl='http://feeds.feedburner.com/ak_blog' />
-      <outline htmlUrl='http://ryanjoy.com' text='Ryan Joy (atxryan)' title='Ryan Joy (atxryan)' type='rss' xmlUrl='http://ryanjoy.com/feed/' />
-      <outline htmlUrl='http://ryanmorr.com' text='Ryan Morr' title='Ryan Morr' type='rss' xmlUrl='http://ryanmorr.com/feed' />
-      <outline htmlUrl='http://sarajchipps.com/' text='Sara Chipps' title='Sara Chipps' type='rss' xmlUrl='http://sarajchipps.com/rss' />
-      <outline htmlUrl='http://sarasoueidan.com' text='SaraSoueidan.com' title='SaraSoueidan.com' type='rss' xmlUrl='http://feeds.feedburner.com/sarasoueidan' />
-      <outline htmlUrl='http://scottkellum.com/' text='Scott Kellum' title='Scott Kellum' type='rss' xmlUrl='http://scottkellum.com/feed.xml' />
-      <outline htmlUrl='http://simplebits.com/' text='SimpleBits' title='SimpleBits' type='rss' xmlUrl='http://simplebits.com/feed' />
-      <outline htmlUrl='http://simurai.com' text='Simurai' title='Simurai' type='rss' xmlUrl='http://simurai.com/rss' />
-      <outline htmlUrl='http://snook.ca/' text='Jonathan Snook' title='Jonathan Snook' type='rss' xmlUrl='http://feeds.feedburner.com/snookca' />
-      <outline htmlUrl='http://softwareas.com' text="Software As She's Developed" title="Software As She's Developed" type='rss' xmlUrl='http://softwareas.com/feed' />
-      <outline htmlUrl='http://stephanierieger.com' text='Stephanie Rieger' title='Stephanie Rieger' type='rss' xmlUrl='http://stephanierieger.com/feed/' />
-      <outline htmlUrl='http://speckyboy.com' text='Speckyboy Design Magazine' title='Speckyboy Design Magazine' type='rss' xmlUrl='http://feeds.feedburner.com/speckboy-design-magazine' />
-      <outline htmlUrl='http://terrywhite.com' text="Terry White's Tech Blog" title="Terry White's Tech Blog" type='rss' xmlUrl='http://terrywhite.com/techblog/feed' />
-      <outline htmlUrl='http://thenewcode.com' text='demosthenes.info' title='demosthenes.info' type='rss' xmlUrl='http://demosthenes.info/feed.php' />
-      <outline htmlUrl='http://thibaudb.com/' text='Thibaud B.' title='Thibaud B.' type='rss' xmlUrl='http://thibaudb.com/rss/' />
-      <outline htmlUrl='http://timo-ernst.net' text='Timo Ernst | Web Architect' title='Timo Ernst | Web Architect' type='rss' xmlUrl='http://www.timo-ernst.net/feed/' />
-      <outline htmlUrl='http://tom.preston-werner.com/' text='Tom Preston' title='Tom Preston' type='rss' xmlUrl='http://feeds.feedburner.com/tom-preston-werner' />
-      <outline htmlUrl='http://trentwalton.com' text='Trent Walton' title='Trent Walton' type='rss' xmlUrl='http://trentwalton.com/feed/' />
-      <outline htmlUrl='http://tympanus.net/codrops' text='Codrops' title='Codrops' type='rss' xmlUrl='http://feeds.feedburner.com/codrops' />
-      <outline htmlUrl='http://typedarray.org' text='TypedArray.org' title='TypedArray.org' type='rss' xmlUrl='http://typedarray.org/feed/' />
-      <outline htmlUrl='http://webaim.org/blog' text='WebAIM Blog' title='WebAIM Blog' type='rss' xmlUrl='http://webaim.org/blog/feed' />
-      <outline htmlUrl='http://webdesignerwall.com' text='Web Designer Wall - Design Trends and Tutorials' title='Web Designer Wall - Design Trends and Tutorials' type='rss' xmlUrl='http://www.webdesignerwall.com/feed/' />
-      <outline htmlUrl='http://webreflection.blogspot.com/' text='Web Reflection' title='Web Reflection' type='rss' xmlUrl='http://feeds.feedburner.com/WebReflection' />
-      <outline htmlUrl="http://www.2ality.com/" text="②ality – JavaScript and more" title="②ality – JavaScript and more" type="rss" xmlUrl="http://www.2ality.com/feeds/posts/default"/>
-      <outline htmlUrl='http://www.andrewkelsall.com' text='Andrew Kelsall' title='. Andrew Kelsall' type='rss' xmlUrl='http://feeds.feedburner.com/AndrewKelsall' />
-      <outline htmlUrl='http://www.atomtips.com' text='Atom Editor Tips and Tricks' title='Atom Editor Tips and Tricks' type='rss' xmlUrl='http://www.atomtips.com/feed/' />
-      <outline htmlUrl='http://www.benbarnett.net/' text="Ben Barnett's Blog" title="Ben Barnett's Blog" type='rss' xmlUrl='http://www.benbarnett.net/blog?format=RSS' />
-      <outline htmlUrl='http://www.andismith.com' text='AndiSmith.com » Blog' title='AndiSmith.com » Blog' type='rss' xmlUrl='http://feeds.feedburner.com/andismith' />
-      <outline htmlUrl='http://www.bennadel.com/' text="Ben Nadel's Web Development and User Experience Feed @ BenNadel.com" title="Ben Nadel's Web Development and User Experience Feed @ BenNadel.com" type='rss' xmlUrl='http://www.bennadel.com/index.cfm?dax=blog.rss&amp;lst_tag_id=14,16,3,5,9,6,7,13,18,20,10,15' />
-      <outline htmlUrl='http://www.bitovi.com' text='JavaScript Consulting &amp; Training  Bitovi' title='JavaScript Consulting &amp; Training  Bitovi' type='rss' xmlUrl='http://feeds.feedburner.com/JupiterMain' />
-      <outline htmlUrl='http://www.bitstampede.com' text='Bit Stampede' title='Bit Stampede' type='rss' xmlUrl='http://www.bitstampede.com/feed/' />
-      <outline htmlUrl='http://www.blueskyonmars.com' text='Blue Sky On Mars' title='Blue Sky On Mars' type='rss' xmlUrl='http://feeds.feedburner.com/blueskyonmars/all' />
-      <outline htmlUrl='http://www.broken-links.com' text='Broken Links' title='Broken Links' type='rss' xmlUrl='http://feeds.feedburner.com/PeterGasstonsGeekBlog' />
-      <outline htmlUrl='http://www.brucelawson.co.uk' text='Bruce Lawson' title='Bruce Lawson' type='rss' xmlUrl='http://www.brucelawson.co.uk/feed/' />
-      <outline htmlUrl='http://www.cappuccino-project.org/blog/' text='Cappuccino Blog' title='Cappuccino Blog' type='rss' xmlUrl='http://www.cappuccino-project.org/blog/feed.xml' />
-      <outline htmlUrl="http://www.echojs.com" text="Echo JS" title="Echo JS" type="rss" xmlUrl="http://www.echojs.com/rss"/>
-      <outline htmlUrl='http://www.elmastudio.de/en/' text='Elmastudio' title='Elmastudio' type='rss' xmlUrl='http://www.elmastudio.de/en/feed/' />
-      <outline htmlUrl='http://www.geekswhoknowtheirshit.com' text='Geeks Who Know Their Shit' title='Geeks Who Know Their Shit' type='rss' xmlUrl='http://www.geekswhoknowtheirshit.com/feed/' />
-      <outline htmlUrl='http://www.idangero.us' text='iDangerous: Home of Framework7 + Slider.js' title='iDangerous: Home of Framework7 + Slider.js' type='rss' xmlUrl='http://www.idangero.us/rss/news-feed.xml' />
-      <outline htmlUrl='http://www.impressivewebs.com' text='Impressive Webs' title='Impressive Webs' type='rss' xmlUrl='http://feeds.feedburner.com/ImpressiveWebs' />
-      <outline htmlUrl='http://www.joelambert.co.uk/articles.rss' text='Joe Lambert' title='Joe Lambert' type='rss' xmlUrl='http://www.joelambert.co.uk/articles.rss' />
-      <outline htmlUrl='http://www.learningjquery.com' text='Learning jQuery' title='Learning jQuery' type='rss' xmlUrl='http://feeds.feedburner.com/LearningJquery' />
-      <outline htmlUrl='http://www.phoboslab.org/log' text='PhobosLab' title='PhobosLab' type='rss' xmlUrl='http://www.phoboslab.org/log/feed' />
-      <outline htmlUrl='http://www.phpied.com' text='phpied.com' title='phpied.com' type='rss' xmlUrl='http://www.phpied.com/feed/' />
-      <outline htmlUrl='http://www.position-absolute.com' text='Position Absolute' title='Position Absolute' type='rss' xmlUrl='http://feeds2.feedburner.com/position-absolute/nyJv' />
-      <outline htmlUrl='http://www.quirksmode.org/blog/' text='QuirksBlog' title='QuirksBlog' type='rss' xmlUrl='http://www.quirksmode.org/blog/atom.xml' />
-      <outline htmlUrl='http://www.sazzy.co.uk' text='Sarah Parmenter' title='Sarah Parmenter' type='rss' xmlUrl='http://www.sazzy.co.uk/feed/' />
-      <outline htmlUrl='http://www.sjespers.com/blog/' text='Serge Jespers' title='Serge Jespers' type='rss' xmlUrl='http://www.sjespers.com/blog?format=RSS' />
-      <outline htmlUrl='http://www.smashingmagazine.com' text='Smashing Magazine' title='Smashing Magazine' type='rss' xmlUrl='http://www.smashingmagazine.com/feed/' />
-      <outline htmlUrl='http://www.stevesouders.com/blog' text='High Performance Web Sites' title='High Performance Web Sites' type='rss' xmlUrl='http://www.stevesouders.com/blog/feed/atom/' />
-      <outline htmlUrl='http://www.sublimetext.com/blog' text='Sublime Blog' title='Sublime Blog' type='rss' xmlUrl='http://www.sublimetext.com/blog/feed' />
-      <outline htmlUrl='http://www.thecssninja.com' text='The CSS Ninja' title='The CSS Ninja' type='rss' xmlUrl='http://feeds.feedburner.com/TheCSSNinja' />
-      <outline htmlUrl='http://www.thespanner.co.uk' text='The Spanner' title='The Spanner' type='rss' xmlUrl='http://www.thespanner.co.uk/feed/' />
-      <outline htmlUrl='http://www.validatethis.co.uk' text='ValidateThis' title='ValidateThis' type='rss' xmlUrl='http://www.validatethis.co.uk/feed/' />
-      <outline htmlUrl='http://www.webdesignerdepot.com' text='Webdesigner Depot' title='Webdesigner Depot' type='rss' xmlUrl='http://www.webdesignerdepot.com/feed/' />
-      <outline htmlUrl='http://www.webdirections.org' text='Web Directions' title='Web Directions' type='rss' xmlUrl='http://www.webdirections.org/category/blog/feed' />
-      <outline htmlUrl='http://www.webperformancetoday.com' text='Web Performance Today' title='Web Performance Today' type='rss' xmlUrl='http://www.webperformancetoday.com/feed/' />
-      <outline htmlUrl='http://www.www.zkoss.org' text='SourceForge.net: SF.net Project News: ZK - Simply Ajax and Mobile' title='SourceForge.net: SF.net Project News: ZK - Simply Ajax and Mobile' type='rss' xmlUrl='http://feeds.feedburner.com/zkoss' />
-      <outline htmlUrl='http://www.zachleat.com/web/' text='zachleat.com' title='zachleat.com' type='rss' xmlUrl='http://www.zachleat.com/web/feed/' />
-      <outline htmlUrl='http://www.zeldman.com' text='Zeldman on Web &amp; Interaction Design' title='Zeldman on Web &amp; Interaction Design' type='rss' xmlUrl='http://www.zeldman.com/feed/zeldman.xml' />
-      <outline htmlUrl='http://yahooeng.tumblr.com/' text='Yahoo Engineering' title='Yahoo Engineering' type='rss' xmlUrl='http://yahooeng.tumblr.com/rss' />
-      <outline htmlUrl='http://yeoman.io' text='Yeoman Blog' title='Yeoman Blog' type='rss' xmlUrl='http://yeoman.io/blog/atom.xml' />
-      <outline htmlUrl='http://zoompf.com' text='Lickity Split' title='Lickity Split' type='rss' xmlUrl='http://zoompf.com/blog/feed/' />
-      <outline htmlUrl='https://mikewest.org/' text='Mike West' title='Mike West' type='rss' xmlUrl='https://mikewest.org/rss' />
-      <outline htmlUrl='http://zurb.com/blog/posts' text='ZURB' title='ZURB' type='rss' xmlUrl='http://feeds.feedburner.com/zurb/blog' />
-      <outline htmlUrl='https://adactio.com/articles/' text='Adactio: Articles' title='Adactio: Articles' type='rss' xmlUrl='http://adactio.com/articles/rss' />
-      <outline htmlUrl='https://blog.domenic.me/' text='Hidden Variables' title='Hidden Variables' type='rss' xmlUrl='http://domenic.me/atom.xml' />
-      <outline htmlUrl='https://blog.getfirebug.com' text='Getfirebug Blog' title='Getfirebug Blog' type='rss' xmlUrl='http://blog.getfirebug.com/?feed=rss2' />
-      <outline htmlUrl='http://creativejs.com' text='CreativeJS' title='CreativeJS' type='rss' xmlUrl='http://feeds.feedburner.com/CreativeJS' />
-      <outline htmlUrl='https://css-tricks.com' text='CSS-Tricks' title='CSS-Tricks' type='rss' xmlUrl='http://feeds.feedburner.com/CssTricks' />
-      <outline htmlUrl='https://devblog.xing.com' text='XING Devblog' title='XING Devblog' type='rss' xmlUrl='http://devblog.xing.com/category/frontend/feed/' />
-      <outline htmlUrl='https://developers.facebook.com/blog/' text='Facebook Developers' title='Facebook Developers' type='rss' xmlUrl='http://developers.facebook.com/blog/feed' />
-      <outline htmlUrl='https://drublic.de/blog' text='drublic' title='@drublic' type='rss' xmlUrl='http://feeds.feedburner.com/drublic' />
-      <outline htmlUrl='https://facebook.github.io/react' text='React' title='React' type='rss' xmlUrl='http://facebook.github.io/react/feed.xml' />
-      <outline htmlUrl='https://github.com/blog' text='The GitHub Blog' title='The GitHub Blog' type='rss' xmlUrl='https://github.com/blog.atom' />
-      <outline htmlUrl='https://infrequently.org' text='Continuing Intermittent Incoherency' title='Continuing Intermittent Incoherency' type='rss' xmlUrl='http://infrequently.org/feed/atom/' />
-      <outline htmlUrl='https://mathiasbynens.be/notes' text='Mathias Bynens' title='Mathias Bynens' type='rss' xmlUrl='http://mathiasbynens.be/notes.atom' />
-      <outline htmlUrl='https://medium.com/@maxlynch?source=rss-a76fa51de1ba------2' text='Max Lynch on Medium' title='Max Lynch on Medium' type='rss' xmlUrl='https://medium.com/feed/@maxlynch' />
-      <outline htmlUrl='https://medium.com/@tomastrajan?source=rss-360cd444e1fc------2' text='Tomas Trajan' title='Tomas Trajan' type='rss' xmlUrl='https://medium.com/feed/@tomastrajan' />
-      <outline htmlUrl="https://medium.com/javascript-scene?source=rss----c0aeac5284ad---4" text="JavaScript Scene" title="JavaScript Scene" type="rss" xmlUrl="https://medium.com/feed/javascript-scene"/>
-      <outline htmlUrl='https://nodejs.org/en/' text='Node.js Blog' title='Node.js Blog' type='rss' xmlUrl='http://blog.nodejs.org/feed/' />
-      <outline htmlUrl='https://paulbakaus.com' text='The Sea of Ideas' title='The Sea of Ideas' type='rss' xmlUrl='http://feeds.feedburner.com/TheSeaOfIdeas' />
-      <outline htmlUrl='https://reactjsnews.com/' text='ReactJS News' title='ReactJS News' type='rss' xmlUrl='https://reactjsnews.com/feed.xml' />
-      <outline htmlUrl='https://remysharp.com' text='Remy Sharp' title='Remy Sharp' type='rss' xmlUrl='http://feeds.feedburner.com/remysharp' />
-      <outline htmlUrl="https://rreverser.com/" text="RReverser's" title="RReverser's" type="rss" xmlUrl="https://rreverser.com/rss/"/>
-      <outline htmlUrl="https://scotch.io" text="Scotch" title="Scotch" type="rss" xmlUrl="http://scotch.io/feed"/>
-      <outline htmlUrl='https://subjunctive.wordpress.com' text='If only I were' title='If only I were' type='rss' xmlUrl='http://subjunctive.wordpress.com/feed/' />
-      <outline htmlUrl='https://weston.ruter.net' text='Weston Ruter' title='Weston Ruter' type='rss' xmlUrl='http://feeds.feedburner.com/westonruter' />
-      <outline htmlUrl='https://wpaxl.com' text='WP Axl' title='WP Axl' type='rss' xmlUrl='http://wpaxl.com/feed/' />
-      <outline htmlUrl='http://calendar.perfplanet.com' text='Performance Calendar' title='Performance Calendar' type='rss' xmlUrl='http://calendar.perfplanet.com/feed/' />
-      <outline htmlUrl='http://bricss.net/' text='Bricss' title='Bricss' type='rss' xmlUrl='http://bricss.net/rss' />
-      <outline htmlUrl='https://www.christianheilmann.com' text='Christian Heilmann' title='Christian Heilmann' type='rss' xmlUrl='http://www.wait-till-i.com/wp-atom.php' />
-      <outline htmlUrl='https://www.chromeexperiments.com' text='Chrome Experiments' title='Chrome Experiments' type='rss' xmlUrl='http://www.chromeexperiments.com/feed/' />
-      <outline htmlUrl='https://www.igvita.com' text='igvita.com' title='igvita.com' type='rss' xmlUrl='http://feeds.igvita.com/igvita' />
-      <outline htmlUrl='https://www.marcozehe.de' text="Marco's accessibility blog" title="Marco's accessibility blog" type='rss' xmlUrl='http://www.marcozehe.de/feed/' />
-      <outline htmlUrl='https://www.mongodb.com/blog' text='MongoDB | Blog' title='MongoDB | Blog' type='rss' xmlUrl='http://blog.10gen.com/rss' />
-      <outline htmlUrl='https://www.nczonline.net/' text='NCZOnline' title='NCZOnline' type='rss' xmlUrl='http://feeds.feedburner.com/nczonline' />
-      <outline htmlUrl='https://www.sencha.com' text='Sencha Blog' title='Sencha Blog' type='rss' xmlUrl='http://feeds.feedburner.com/extblog' />
-      <outline htmlUrl='https://www.webreflection.co.uk/' text='WebReflection Limited' title='WebReflection Limited' type='rss' xmlUrl='https://www.webreflection.co.uk/blog/feed.atom' />
-      <outline htmlUrl='https://xhtmlized.com' text='XHTMLized' title='XHTMLized' type='rss' xmlUrl='http://feeds.feedburner.com/XHTMLized' />
-      <outline htmlUrl='https://www.ashleynolan.co.uk/' text='AshleyNolan.co.uk' title='AshleyNolan.co.uk' type='rss' xmlUrl='https://ashleynolan.co.uk/feed.xml' />
-      <outline htmlUrl='http://remarkablemark.org/' text='remarkablemark' title='remarkablemark' type='rss' xmlUrl='http://remarkablemark.org/feed.xml' />      
-      <outline text='John Nunemaker' title='John Nunemaker' type='rss' xmlUrl='http://johnnunemaker.com/atom.xml' />
+    <outline text="frontend" title="frontend">
+      <outline text="Aerotwist Blog" title="Aerotwist Blog" type="rss" xmlUrl="http://aerotwist.com/blog/feed/" htmlUrl="http://aerotwist.com/blog/feed/"/>
+      <outline text="Alex Sexton" title="Alex Sexton" type="rss" xmlUrl="http://alexsexton.com/?feed=rss2" htmlUrl="https://alexsexton.com/"/>
+      <outline text="A List Apart" title="A List Apart" type="rss" xmlUrl="http://www.alistapart.com/rss.xml" htmlUrl="http://alistapart.com/"/>
+      <outline text="Alex Gibson" title="Alex Gibson" type="rss" xmlUrl="http://alxgbsn.co.uk/feed/" htmlUrl="http://alxgbsn.co.uk/"/>
+      <outline text="AngularJS" title="AngularJS" type="rss" xmlUrl="http://blog.angularjs.org/feeds/posts/default" htmlUrl="http://angularjs.blogspot.com/"/>
+      <outline text="antimatter15" title="antimatter15" type="rss" xmlUrl="http://antimatter15.com/wp/feed/" htmlUrl="http://localhost/wp"/>
+      <outline text="Badass JavaScript" title="Badass JavaScript" type="rss" xmlUrl="http://rss.badassjs.com/" htmlUrl="http://badassjs.com/"/>
+      <outline text="Ben Frain" title="Ben Frain" type="rss" xmlUrl="http://benfrain.com/feed/" htmlUrl="http://benfrain.com/"/>
+      <outline text="Ben Smithett" title="Ben Smithett" type="rss" xmlUrl="http://bensmithett.com/feed.xml" htmlUrl="http://blog.bensmithett.com/"/>
+      <outline text="Atom Blog" title="Atom Blog" type="rss" xmlUrl="http://blog.atom.io/feed.xml" htmlUrl="http://blog.atom.io/"/>
+      <outline text="Brackets Blog" title="Brackets Blog" type="rss" xmlUrl="http://blog.brackets.io/feed/" htmlUrl="http://blog.brackets.io/"/>
+      <outline text="Cloud Four Blog" title="Cloud Four Blog" type="rss" xmlUrl="http://blog.cloudfour.com/feed/" htmlUrl="http://blog.cloudfour.com/"/>
+      <outline text="CouchDB Blog" title="CouchDB Blog" type="rss" xmlUrl="http://blog.couchdb.org/feed/" htmlUrl="http://blog.couchdb.org/"/>
+      <outline text="Dave Balmer" title="Dave Balmer" type="rss" xmlUrl="http://blog.davebalmer.com/rss/" htmlUrl="http://blog.davebalmer.com/"/>
+      <outline text="Bootstrap Blog" title="Bootstrap Blog" type="rss" xmlUrl="http://blog.getbootstrap.com/feed.xml" htmlUrl="http://blog.getbootstrap.com/"/>
+      <outline text="jQuery Blog" title="jQuery Blog" type="rss" xmlUrl="http://feeds.feedburner.com/jquery/" htmlUrl="http://blog.jquery.com/"/>
+      <outline text="Keith Cirkel" title="Keith Cirkel" type="rss" xmlUrl="http://blog.keithcirkel.co.uk/rss/" htmlUrl="http://blog.keithcirkel.co.uk/"/>
+      <outline text="Performance Matters" title="Performance Matters" type="rss" xmlUrl="http://blog.patrickmeenan.com/feeds/posts/default" htmlUrl="http://blog.patrickmeenan.com/"/>
+      <outline text="Rey Bango" title="Rey Bango" type="rss" xmlUrl="http://blog.reybango.com/feed/" htmlUrl="http://blog.reybango.com/"/>
+      <outline text="Vjeux" title="Vjeux" type="rss" xmlUrl="http://blog.vjeux.com/feed" htmlUrl="http://blog.vjeux.com/"/>
+      <outline text="TojiCode" title="TojiCode" type="rss" xmlUrl="http://blog.tojicode.com/feeds/posts/default" htmlUrl="http://blog.tojicode.com/"/>
+      <outline text="The ZK Blog" title="The ZK Blog" type="rss" xmlUrl="http://blog.zkoss.org/index.php/feed/" htmlUrl="http://blog.zkoss.org"/>
+      <outline text="TypeScript" title="TypeScript" type="rss" xmlUrl="http://blogs.msdn.com/b/typescript/rss.aspx" htmlUrl="http://blogs.msdn.com/b/typescript/"/>
+      <outline text="Brad Frost »" title="Brad Frost »" type="rss" xmlUrl="http://feeds.feedburner.com/brad-frosts-blog" htmlUrl="http://bradfrost.com/"/>
+      <outline text="Nettuts+" title="Nettuts+" type="rss" xmlUrl="http://net.tutsplus.com/feed/" htmlUrl="http://code.tutsplus.com/"/>
+      <outline text="Christophe Coenraets" title="Christophe Coenraets" type="rss" xmlUrl="http://coenraets.org/blog/feed/" htmlUrl="http://coenraets.org/blog"/>
+      <outline text="Matteo Spinelli's Cubiq.org" title="Matteo Spinelli's Cubiq.org" type="rss" xmlUrl="http://cubiq.org/feed" htmlUrl="http://cubiq.org/"/>
+      <outline text="DailyJS" title="DailyJS" type="rss" xmlUrl="http://feeds.feedburner.com/dailyjs" htmlUrl="http://dailyjs.com/"/>
+      <outline text="The Dapper Developer" title="The Dapper Developer" type="rss" xmlUrl="http://dapperdeveloper.com/feed/" htmlUrl="http://dapperdeveloper.com/"/>
+      <outline text="daverupert.com" title="daverupert.com" type="rss" xmlUrl="http://daverupert.com/atom.xml" htmlUrl="http://daverupert.com/"/>
+      <outline text="David Walsh Blog" title="David Walsh Blog" type="rss" xmlUrl="http://feeds.feedburner.com/Bludice" htmlUrl="http://davidwalsh.name/"/>
+      <outline text="Devgirl's Weblog" title="Devgirl's Weblog" type="rss" xmlUrl="http://devgirl.org/feed/" htmlUrl="http://devgirl.org/"/>
+      <outline text="Dilbert Daily Strip" title="Dilbert Daily Strip" type="rss" xmlUrl="http://feeds.feedburner.com/DilbertDailyStrip" htmlUrl="http://dilbert.com/"/>
+      <outline text="ecmanaut" title="ecmanaut" type="rss" xmlUrl="http://feeds.feedburner.com/ecmanaut" htmlUrl="http://ecmanaut.blogspot.com/"/>
+      <outline text="John Resig" title="John Resig" type="rss" xmlUrl="http://feeds.feedburner.com/JohnResig" htmlUrl="http://ejohn.org/"/>
+      <outline text="Ember Blog" title="Ember Blog" type="rss" xmlUrl="http://emberjs.com/blog/feed.xml" htmlUrl="http://emberjs.com/blog"/>
+      <outline text="Eli Grey" title="Eli Grey" type="rss" xmlUrl="http://feeds.feedburner.com/eligrey" htmlUrl="http://eligrey.com/blog"/>
+      <outline text="Felix Geisendörfer" title="Felix Geisendörfer" type="rss" xmlUrl="http://feeds.feedburner.com/felixge" htmlUrl="http://felixge.de/"/>
+      <outline text="arv-o-matic: The Weblog of Erik Arvidsson" title="arv-o-matic: The Weblog of Erik Arvidsson" type="rss" xmlUrl="http://erik.eae.net/feed/atom/" htmlUrl="http://erik.eae.net/"/>
+      <outline text="Nick Fitzgerald" title="Nick Fitzgerald" type="rss" xmlUrl="http://fitzgeraldnick.com/weblog/feeds/latest-atom/" htmlUrl="http://fitzgeraldnick.com/weblog/"/>
+      <outline text="GitHub Engineering" title="GitHub Engineering" type="rss" xmlUrl="http://githubengineering.com/atom.xml" htmlUrl="http://githubengineering.com/"/>
+      <outline text="The Official Google Blog" title="The Official Google Blog" type="rss" xmlUrl="http://googleblog.blogspot.com/feeds/posts/default?alt=rss" htmlUrl="http://googleblog.blogspot.com/"/>
+      <outline text="Google Webmaster Central Blog" title="Google Webmaster Central Blog" type="rss" xmlUrl="http://feeds.feedburner.com/blogspot/amDG" htmlUrl="http://googlewebmastercentral.blogspot.com/"/>
+      <outline text="Grunt Blog Feed" title="Grunt Blog Feed" type="rss" xmlUrl="http://gruntjs.com/rss" htmlUrl="http://gruntjs.com/"/>
+      <outline text="HTML5 Doctor" title="HTML5 Doctor" type="rss" xmlUrl="http://feeds.feedburner.com/html5doctor" htmlUrl="http://html5doctor.com/"/>
+      <outline text="HTML + CSS + JavaScript" title="HTML + CSS + JavaScript" type="rss" xmlUrl="http://feeds.feedburner.com/HtmlCssJavascript" htmlUrl="http://htmlcssjavascript.com/"/>
+      <outline text="Inspect Element" title="Inspect Element" type="rss" xmlUrl="http://feeds.feedburner.com/inspectelement" htmlUrl="http://inspectelement.com"/>
+      <outline text="Jake Archibald's Blog" title="Jake Archibald's Blog" type="rss" xmlUrl="http://jakearchibald.com/posts.rss" htmlUrl="http://jakearchibald.com/"/>
+      <outline text="James Padolsey" title="James Padolsey" type="rss" xmlUrl="http://feeds.feedburner.com/JamesPadolsey" htmlUrl="http://james.padolsey.com/"/>
+      <outline text="japh(r) by Chris Strom" title="japh(r) by Chris Strom" type="rss" xmlUrl="http://japhr.blogspot.com/feeds/posts/default" htmlUrl="http://japhr.blogspot.com/"/>
+      <outline text="JavaScript Weekly" title="JavaScript Weekly" type="rss" xmlUrl="http://javascriptweekly.com/rss" htmlUrl="http://javascriptweekly.com/"/>
+      <outline text="Joshua Hibbert" title="Joshua Hibbert" type="rss" xmlUrl="http://feeds.feedburner.com/joshnh" htmlUrl="http://joshnh.com/"/>
+      <outline text="Lea Verou" title="Lea Verou" type="rss" xmlUrl="http://feeds2.feedburner.com/leaverou" htmlUrl="http://lea.verou.me/"/>
+      <outline text="Learning Three.js" title="Learning Three.js" type="rss" xmlUrl="http://feeds.feedburner.com/LearningThreejs" htmlUrl="http://learningthreejs.com/"/>
+      <outline text="Learning WebGL" title="Learning WebGL" type="rss" xmlUrl="http://learningwebgl.com/blog/?feed=rss2" htmlUrl="http://learningwebgl.com/blog"/>
+      <outline text="Loige" title="Loige" type="rss" xmlUrl="http://loige.com/rss/" htmlUrl="http://loige.com/"/>
+      <outline text="Mark Grabanski" title="Mark Grabanski" type="rss" xmlUrl="http://feeds.feedburner.com/allTrades" htmlUrl="http://marcgrabanski.com/"/>
+      <outline text="Mark Otto" title="Mark Otto" type="rss" xmlUrl="http://feeds.feedburner.com/mdo" htmlUrl="http://markdotto.com/"/>
+      <outline text="Thoughts From Eric" title="Thoughts From Eric" type="rss" xmlUrl="http://meyerweb.com/eric/thoughts/rss2/summary" htmlUrl="http://meyerweb.com/eric/thoughts"/>
+      <outline text="mir.aculo.us" title="mir.aculo.us" type="rss" xmlUrl="http://feeds.feedburner.com/miraculous" htmlUrl="http://mir.aculo.us/"/>
+      <outline text="Mathias Bynens" title="Mike Street" type="rss" xmlUrl="https://www.mikestreety.co.uk/rss" htmlUrl="https://www.mikestreety.co.uk/"/>
+      <outline text="Mirco Zeiss" title="Mirco Zeiss" type="rss" xmlUrl="http://mircozeiss.com/atom.xml" htmlUrl="http://mircozeiss.com//"/>
+      <outline text="N.Design Studio | Design Blog & Portfolio" title="N.Design Studio | Design Blog & Portfolio" type="rss" xmlUrl="http://ndesign-studio.com/feed" htmlUrl="http://ndesign-studio.com/"/>
+      <outline text="Nicolas Gallagher" title="Nicolas Gallagher" type="rss" xmlUrl="http://nicolasgallagher.com/category/code/feed/" htmlUrl="http://nicolasgallagher.com/"/>
+      <outline text="npmawesome.com" title="npmawesome.com" type="rss" xmlUrl="http://feeds.feedburner.com/npmawesome" htmlUrl="http://npmawesome.com/"/>
+      <outline text="Osvaldas Valutis" title="Osvaldas Valutis" type="rss" xmlUrl="http://osvaldas.info/rss/blog" htmlUrl="http://osvaldas.info/"/>
+      <outline text="Paula Borowska" title="Paula Borowska" type="rss" xmlUrl="http://paulaborowska.com/feed/" htmlUrl="http://paulaborowska.com/"/>
+      <outline text="Paul Rouget" title="Paul Rouget" type="rss" xmlUrl="http://paulrouget.com/index.xml" htmlUrl="http://paulrouget.com/"/>
+      <outline text="Paul Irish" title="Paul Irish" type="rss" xmlUrl="http://feeds.feedburner.com/paul-irish" htmlUrl="http://paulirish.com/"/>
+      <outline text="Paweł Hajdan's Dev Blog" title="Paweł Hajdan's Dev Blog" type="rss" xmlUrl="http://feeds.feedburner.com/PawelHajdansDevBlog" htmlUrl="http://phajdan-jr.blogspot.com/"/>
+      <outline text="pmuellr" title="pmuellr" type="rss" xmlUrl="http://pmuellr.blogspot.com/feeds/posts/default" htmlUrl="http://pmuellr.blogspot.com/"/>
+      <outline text="Robert's talk" title="Robert's talk" type="rss" xmlUrl="http://feeds.feedburner.com/robertnyman" htmlUrl="http://robertnyman.com/"/>
+      <outline text="Alex Kessinger - engineer, creator, collector" title="Alex Kessinger - engineer, creator, collector" type="rss" xmlUrl="http://feeds.feedburner.com/ak_blog" htmlUrl="http://feeds.feedburner.com/"/>
+      <outline text="Ryan Morr" title="Ryan Morr" type="rss" xmlUrl="http://ryanmorr.com/feed" htmlUrl="http://ryanmorr.com/"/>
+      <outline text="SaraSoueidan.com" title="SaraSoueidan.com" type="rss" xmlUrl="http://feeds.feedburner.com/sarasoueidan" htmlUrl="http://sarasoueidan.com/"/>
+      <outline text="SimpleBits" title="SimpleBits" type="rss" xmlUrl="http://simplebits.com/feed" htmlUrl="http://simplebits.com/"/>
+      <outline text="Simurai" title="Simurai" type="rss" xmlUrl="http://simurai.com/rss" htmlUrl="http://simurai.com/"/>
+      <outline text="Jonathan Snook" title="Jonathan Snook" type="rss" xmlUrl="http://feeds.feedburner.com/snookca" htmlUrl="http://snook.ca/"/>
+      <outline text="Software As She's Developed" title="Software As She's Developed" type="rss" xmlUrl="http://softwareas.com/feed" htmlUrl="http://softwareas.com/"/>
+      <outline text="Speckyboy Design Magazine" title="Speckyboy Design Magazine" type="rss" xmlUrl="http://feeds.feedburner.com/speckboy-design-magazine" htmlUrl="http://speckyboy.com/"/>
+      <outline text="Terry White's Tech Blog" title="Terry White's Tech Blog" type="rss" xmlUrl="http://terrywhite.com/techblog/feed" htmlUrl="http://terrywhite.com/"/>
+      <outline text="demosthenes.info" title="demosthenes.info" type="rss" xmlUrl="http://demosthenes.info/feed.php" htmlUrl="http://demosthenes.info/blog"/>
+      <outline text="Timo Ernst | Web Architect" title="Timo Ernst | Web Architect" type="rss" xmlUrl="http://www.timo-ernst.net/feed/" htmlUrl="http://www.timo-ernst.net/"/>
+      <outline text="Tom Preston" title="Tom Preston" type="rss" xmlUrl="http://feeds.feedburner.com/tom-preston-werner" htmlUrl="http://tom.preston-werner.com/"/>
+      <outline text="Codrops" title="Codrops" type="rss" xmlUrl="http://feeds.feedburner.com/codrops" htmlUrl="http://tympanus.net/codrops"/>
+      <outline text="TypedArray.org" title="TypedArray.org" type="rss" xmlUrl="http://typedarray.org/feed/" htmlUrl="http://typedarray.org/"/>
+      <outline text="WebAIM Blog" title="WebAIM Blog" type="rss" xmlUrl="http://webaim.org/blog/feed" htmlUrl="http://webaim.org/blog"/>
+      <outline text="Web Designer Wall - Design Trends and Tutorials" title="Web Designer Wall - Design Trends and Tutorials" type="rss" xmlUrl="http://www.webdesignerwall.com/feed/" htmlUrl="http://webdesignerwall.com/"/>
+      <outline text="Web Reflection" title="Web Reflection" type="rss" xmlUrl="http://feeds.feedburner.com/WebReflection" htmlUrl="http://webreflection.blogspot.com/"/>
+      <outline text=". Andrew Kelsall" title=". Andrew Kelsall" type="rss" xmlUrl="http://feeds.feedburner.com/AndrewKelsall" htmlUrl="http://www.andrewkelsall.com/"/>
+      <outline text="AndiSmith.com » Blog" title="AndiSmith.com » Blog" type="rss" xmlUrl="http://feeds.feedburner.com/andismith" htmlUrl="http://www.andismith.com/"/>
+      <outline text="Ben Nadel's Web Development and User Experience Feed @ BenNadel.com" title="Ben Nadel's Web Development and User Experience Feed @ BenNadel.com" type="rss" xmlUrl="http://www.bennadel.com/index.cfm?dax=blog.rss&lst_tag_id=14,16,3,5,9,6,7,13,18,20,10,15" htmlUrl="http://www.bennadel.com/"/>
+      <outline text="JavaScript Consulting & Training Bitovi" title="JavaScript Consulting & Training Bitovi" type="rss" xmlUrl="http://feeds.feedburner.com/JupiterMain" htmlUrl="http://www.bitovi.com/"/>
+      <outline text="Bit Stampede" title="Bit Stampede" type="rss" xmlUrl="http://www.bitstampede.com/feed/" htmlUrl="https://www.bitstampede.com/"/>
+      <outline text="Blue Sky On Mars" title="Blue Sky On Mars" type="rss" xmlUrl="http://feeds.feedburner.com/blueskyonmars/all" htmlUrl="http://www.blueskyonmars.com/"/>
+      <outline text="Broken Links" title="Broken Links" type="rss" xmlUrl="http://feeds.feedburner.com/PeterGasstonsGeekBlog" htmlUrl="http://www.broken-links.com/"/>
+      <outline text="Bruce Lawson" title="Bruce Lawson" type="rss" xmlUrl="http://www.brucelawson.co.uk/feed/" htmlUrl="http://www.brucelawson.co.uk/"/>
+      <outline text="Cappuccino Blog" title="Cappuccino Blog" type="rss" xmlUrl="http://www.cappuccino-project.org/blog/feed.xml" htmlUrl="http://www.cappuccino-project.org/blog/"/>
+      <outline text="Echo JS" title="Echo JS" type="rss" xmlUrl="http://www.echojs.com/rss" htmlUrl="http://www.echojs.com/"/>
+      <outline text="Elmastudio" title="Elmastudio" type="rss" xmlUrl="http://www.elmastudio.de/en/feed/" htmlUrl="http://www.elmastudio.de/en/"/>
+      <outline text="Impressive Webs" title="Impressive Webs" type="rss" xmlUrl="http://feeds.feedburner.com/ImpressiveWebs" htmlUrl="http://www.impressivewebs.com/"/>
+      <outline text="Learning jQuery" title="Learning jQuery" type="rss" xmlUrl="http://feeds.feedburner.com/LearningJquery" htmlUrl="http://www.learningjquery.com/"/>
+      <outline text="PhobosLab" title="PhobosLab" type="rss" xmlUrl="http://www.phoboslab.org/log/feed" htmlUrl="http://www.phoboslab.org/log"/>
+      <outline text="phpied.com" title="phpied.com" type="rss" xmlUrl="http://www.phpied.com/feed/" htmlUrl="http://www.phpied.com/"/>
+      <outline text="Position Absolute" title="Position Absolute" type="rss" xmlUrl="http://feeds2.feedburner.com/position-absolute/nyJv" htmlUrl="http://www.position-absolute.com/"/>
+      <outline text="QuirksBlog" title="QuirksBlog" type="rss" xmlUrl="http://www.quirksmode.org/blog/atom.xml" htmlUrl="http://www.quirksmode.org/blog/"/>
+      <outline text="Sarah Parmenter" title="Sarah Parmenter" type="rss" xmlUrl="http://www.sazzy.co.uk/feed/" htmlUrl="http://www.sazzy.co.uk/"/>
+      <outline text="Smashing Magazine" title="Smashing Magazine" type="rss" xmlUrl="http://www.smashingmagazine.com/feed/" htmlUrl="http://www.smashingmagazine.com/"/>
+      <outline text="High Performance Web Sites" title="High Performance Web Sites" type="rss" xmlUrl="http://www.stevesouders.com/blog/feed/atom/" htmlUrl="http://www.stevesouders.com/blog"/>
+      <outline text="Sublime Blog" title="Sublime Blog" type="rss" xmlUrl="http://www.sublimetext.com/blog/feed" htmlUrl="http://www.sublimetext.com/blog"/>
+      <outline text="The CSS Ninja" title="The CSS Ninja" type="rss" xmlUrl="http://feeds.feedburner.com/TheCSSNinja" htmlUrl="http://www.thecssninja.com/"/>
+      <outline text="The Spanner" title="The Spanner" type="rss" xmlUrl="http://www.thespanner.co.uk/feed/" htmlUrl="http://www.thespanner.co.uk/"/>
+      <outline text="ValidateThis" title="ValidateThis" type="rss" xmlUrl="http://www.validatethis.co.uk/feed/" htmlUrl="http://www.validatethis.co.uk/"/>
+      <outline text="Webdesigner Depot" title="Webdesigner Depot" type="rss" xmlUrl="http://www.webdesignerdepot.com/feed/" htmlUrl="http://www.webdesignerdepot.com/"/>
+      <outline text="Web Directions" title="Web Directions" type="rss" xmlUrl="http://www.webdirections.org/category/blog/feed" htmlUrl="http://www.webdirections.org/"/>
+      <outline text="Web Performance Today" title="Web Performance Today" type="rss" xmlUrl="http://www.webperformancetoday.com/feed/" htmlUrl="http://www.webperformancetoday.com/"/>
+      <outline text="SourceForge.net: SF.net Project News: ZK - Simply Ajax and Mobile" title="SourceForge.net: SF.net Project News: ZK - Simply Ajax and Mobile" type="rss" xmlUrl="http://feeds.feedburner.com/zkoss" htmlUrl="http://www.www.zkoss.org/"/>
+      <outline text="zachleat.com" title="zachleat.com" type="rss" xmlUrl="http://www.zachleat.com/web/feed/" htmlUrl="http://www.zachleat.com/web/"/>
+      <outline text="Zeldman on Web & Interaction Design" title="Zeldman on Web & Interaction Design" type="rss" xmlUrl="http://www.zeldman.com/feed/zeldman.xml" htmlUrl="http://www.zeldman.com/"/>
+      <outline text="Yeoman Blog" title="Yeoman Blog" type="rss" xmlUrl="http://yeoman.io/blog/atom.xml" htmlUrl="http://yeoman.io/"/>
+      <outline text="Mike West" title="Mike West" type="rss" xmlUrl="https://mikewest.org/rss" htmlUrl="https://mikewest.org/"/>
+      <outline text="ZURB" title="ZURB" type="rss" xmlUrl="http://feeds.feedburner.com/zurb/blog" htmlUrl="http://zurb.com/blog/posts"/>
+      <outline text="Adactio: Articles" title="Adactio: Articles" type="rss" xmlUrl="http://adactio.com/articles/rss" htmlUrl="https://adactio.com/articles/"/>
+      <outline text="Hidden Variables" title="Hidden Variables" type="rss" xmlUrl="http://domenic.me/atom.xml" htmlUrl="https://blog.domenic.me/"/>
+      <outline text="Getfirebug Blog" title="Getfirebug Blog" type="rss" xmlUrl="http://blog.getfirebug.com/?feed=rss2" htmlUrl="https://blog.getfirebug.com/"/>
+      <outline text="CSS-Tricks" title="CSS-Tricks" type="rss" xmlUrl="http://feeds.feedburner.com/CssTricks" htmlUrl="http://css-tricks.com/"/>
+      <outline text="Facebook Developers" title="Facebook Developers" type="rss" xmlUrl="http://developers.facebook.com/blog/feed" htmlUrl="https://developers.facebook.com/blog/"/>
+      <outline text="React" title="React" type="rss" xmlUrl="http://facebook.github.io/react/feed.xml" htmlUrl="http://facebook.github.io/react"/>
+      <outline text="Continuing Intermittent Incoherency" title="Continuing Intermittent Incoherency" type="rss" xmlUrl="http://infrequently.org/feed/atom/" htmlUrl="http://infrequently.org/"/>
+      <outline text="Mathias Bynens" title="Mathias Bynens" type="rss" xmlUrl="http://mathiasbynens.be/notes.atom" htmlUrl="https://mathiasbynens.be/notes"/>
+      <outline text="Max Lynch on Medium" title="Max Lynch on Medium" type="rss" xmlUrl="https://medium.com/feed/@maxlynch" htmlUrl="https://medium.com/@maxlynch?source=rss-a76fa51de1ba------2"/>
+      <outline text="Tomas Trajan" title="Tomas Trajan" type="rss" xmlUrl="https://medium.com/feed/@tomastrajan" htmlUrl="https://medium.com/@tomastrajan?source=rss-360cd444e1fc------2"/>
+      <outline text="JavaScript Scene" title="JavaScript Scene" type="rss" xmlUrl="https://medium.com/feed/javascript-scene" htmlUrl="https://medium.com/javascript-scene"/>
+      <outline text="Node.js Blog" title="Node.js Blog" type="rss" xmlUrl="http://blog.nodejs.org/feed/" htmlUrl="http://blog.nodejs.org/"/>
+      <outline text="The Sea of Ideas" title="The Sea of Ideas" type="rss" xmlUrl="http://feeds.feedburner.com/TheSeaOfIdeas" htmlUrl="http://paulbakaus.com/"/>
+      <outline text="ReactJS News" title="ReactJS News" type="rss" xmlUrl="https://reactjsnews.com/feed.xml" htmlUrl="https://reactjsnews.com/"/>
+      <outline text="Remy Sharp" title="Remy Sharp" type="rss" xmlUrl="http://feeds.feedburner.com/remysharp" htmlUrl="http://remysharp.com/"/>
+      <outline text="RReverser's" title="RReverser's" type="rss" xmlUrl="https://rreverser.com/rss/" htmlUrl="https://rreverser.com/"/>
+      <outline text="Scotch" title="Scotch" type="rss" xmlUrl="http://scotch.io/feed" htmlUrl="http://scotch.io/"/>
+      <outline text="If only I were" title="If only I were" type="rss" xmlUrl="http://subjunctive.wordpress.com/feed/" htmlUrl="http://subjunctive.wordpress.com/"/>
+      <outline text="Weston Ruter" title="Weston Ruter" type="rss" xmlUrl="http://feeds.feedburner.com/westonruter" htmlUrl="https://weston.ruter.net/"/>
+      <outline text="WP Axl" title="WP Axl" type="rss" xmlUrl="http://wpaxl.com/feed/" htmlUrl="http://wpaxl.com/"/>
+      <outline text="Performance Calendar" title="Performance Calendar" type="rss" xmlUrl="http://calendar.perfplanet.com/feed/" htmlUrl="http://calendar.perfplanet.com/"/>
+      <outline text="Christian Heilmann" title="Christian Heilmann" type="rss" xmlUrl="http://www.wait-till-i.com/wp-atom.php" htmlUrl="http://christianheilmann.com/"/>
+      <outline text="igvita.com" title="igvita.com" type="rss" xmlUrl="http://feeds.igvita.com/igvita" htmlUrl="https://www.igvita.com/"/>
+      <outline text="Marco's accessibility blog" title="Marco's accessibility blog" type="rss" xmlUrl="http://www.marcozehe.de/feed/" htmlUrl="http://www.marcozehe.de/"/>
+      <outline text="MongoDB | Blog" title="MongoDB | Blog" type="rss" xmlUrl="http://blog.10gen.com/rss" htmlUrl="http://www.mongodb.com/blog"/>
+      <outline text="NCZOnline" title="NCZOnline" type="rss" xmlUrl="http://feeds.feedburner.com/nczonline" htmlUrl="http://www.nczonline.net/blog"/>
+      <outline text="Sencha Blog" title="Sencha Blog" type="rss" xmlUrl="http://feeds.feedburner.com/extblog" htmlUrl="http://www.sencha.com/blog/"/>
+      <outline text="WebReflection Limited" title="WebReflection Limited" type="rss" xmlUrl="https://www.webreflection.co.uk/blog/feed.atom" htmlUrl="https://www.webreflection.co.uk/"/>
+      <outline text="XHTMLized" title="XHTMLized" type="rss" xmlUrl="http://feeds.feedburner.com/XHTMLized" htmlUrl="http://xhtmlized.com/"/>
+      <outline text="AshleyNolan.co.uk" title="AshleyNolan.co.uk" type="rss" xmlUrl="https://ashleynolan.co.uk/feed.xml" htmlUrl="https://www.ashleynolan.co.uk/"/>
+      <outline text="remarkablemark" title="remarkablemark" type="rss" xmlUrl="http://remarkablemark.org/feed.xml" htmlUrl="http://remarkablemark.org/"/>
+      <outline text="John Nunemaker" title="John Nunemaker" type="rss" xmlUrl="http://johnnunemaker.com/atom.xml" htmlUrl="http://johnnunemaker.com/atom.xml"/>
     </outline>
-    <outline text='frontend-standards+browsers' title='frontend-standards+browsers'>
-      <outline htmlUrl='http://blog.chromium.org/' text='Chromium Blog' title='Chromium Blog' type='rss' xmlUrl='http://blog.chromium.org/feeds/posts/default' />
-      <outline htmlUrl='http://blog.html5test.com' text='The HTML5 test' title='The HTML5 test' type='rss' xmlUrl='http://blog.html5test.com/rss' />
-      <outline htmlUrl='http://blogs.opera.com/desktop' text='Opera Desktop' title='Opera Desktop' type='rss' xmlUrl='http://blogs.opera.com/desktop/feed/' />
-      <outline htmlUrl='http://blogs.opera.com/mobile' text='Opera Mobile' title='Opera Mobile' type='rss' xmlUrl='http://blogs.opera.com/mobile/feed/' />
-      <outline htmlUrl='http://blogs.windows.com/msedgedev' text='IEBlog' title='IEBlog' type='rss' xmlUrl='http://blogs.msdn.com/b/ie/atom.aspx' />
-      <outline htmlUrl='http://blogs.windows.com/msedgedev' text='Microsoft Edge Dev Blog' title='Microsoft Edge Dev Blog' type='rss' xmlUrl='http://blogs.msdn.com/ie/rss.xml' />
-      <outline htmlUrl='https://blog.mozilla.org/javascript/' text='JavaScript' title='JavaScript' type='rss' xmlUrl='https://blog.mozilla.org/javascript/feed/' />
-      <outline htmlUrl='http://brendaneich.com' text='Brendan Eich' title='Brendan Eich' type='rss' xmlUrl='http://brendaneich.com/feed/' />
-      <outline htmlUrl='http://caniuse.com/feed.php' text='Can I Use updates' title='Can I Use updates' type='rss' xmlUrl='http://feeds.feedburner.com/WhenCanIUse' />
-      <outline htmlUrl='http://chrome.blogspot.com/' text='Google Chrome Blog' title='Google Chrome Blog' type='rss' xmlUrl='http://feeds2.feedburner.com/blogspot/Egta' />
-      <outline htmlUrl='http://hacks.mozilla.org' text='Mozilla Hacks' title='Mozilla Hacks' type='rss' xmlUrl='http://hacks.mozilla.org/feed/' />
-      <outline htmlUrl='http://jatindersmann.com' text='Jatinder S Mann' title='Jatinder S Mann' type='rss' xmlUrl='http://jatindersmann.com/feed/' />
-      <outline htmlUrl='http://mrale.ph' text='mraleph' title='mraleph' type='rss' xmlUrl='http://mrale.ph/atom.xml' />
-      <outline htmlUrl='http://neugierig.org/software/blog/' text='Tech Notes' title='Tech Notes' type='rss' xmlUrl='http://neugierig.org/software/blog/atom.xml' />
-      <outline htmlUrl='http://peter.sh/' text='Peter Beverloo' title='Peter Beverloo' type='rss' xmlUrl='http://peter.sh/feed/' />
-      <outline htmlUrl='http://planet.webkit.org/' text='Planet WebKit' title='Planet WebKit' type='rss' xmlUrl='http://planet.webkit.org/atom.xml' />
-      <outline htmlUrl='http://robert.ocallahan.org/' text="Robert O'Callahan" title="Robert O'Callahan" type='rss' xmlUrl='http://robert.ocallahan.org/feeds/posts/default' />
-      <outline htmlUrl='http://tavmjong.free.fr/blog' text="Tavmjong Bah's Blog" title="Tavmjong Bah's Blog" type='rss' xmlUrl='http://tavmjong.free.fr/blog/?feed=rss2' />
-      <outline htmlUrl='http://w3cmemes.tumblr.com/' text='W3C Memes' title='W3C Memes' type='rss' xmlUrl='http://w3cmemes.tumblr.com/rss' />
-      <outline htmlUrl='http://webkitmemes.tumblr.com/' text='WebKit memes' title='WebKit memes' type='rss' xmlUrl='http://webkitmemes.tumblr.com/rss' />
-      <outline htmlUrl='http://webplatformdaily.org/' text='Open Web Platform Daily' title='Open Web Platform Daily' type='rss' xmlUrl='http://feeds.feedburner.com/OpenWebPlatformDailyDigest' />
-      <outline htmlUrl='http://www.favbrowser.com' text='Web Browsers News and Reviews' title='Web Browsers News and Reviews' type='rss' xmlUrl='http://feeds.feedburner.com/FavoriteBrowser' />
-      <outline htmlUrl='http://www.glazman.org/weblog/dotclear/index.php?' type='rss' xmlUrl='http://www.glazman.org/weblog/dotclear/index.php?feed/rss2' />
-      <outline htmlUrl='http://www.xanthir.com/blog/' text='Tab Atkins' title='Tab Atkins' type='rss' xmlUrl='http://www.xanthir.com/blog/atom/' />
-      <outline htmlUrl='https://annevankesteren.nl/' text='Anne’s Blog' title='Anne’s Blog' type='rss' xmlUrl='http://annevankesteren.nl/feeds/weblog' />
-      <outline htmlUrl='https://dev.opera.com/' text='Opera Labs' title='Opera Labs' type='rss' xmlUrl='http://dev.opera.com/feeds/rss/articles' />
-      <outline htmlUrl='https://hsivonen.fi/' text='Henri Sivonen’s pages' title='Henri Sivonen’s pages' type='rss' xmlUrl='http://hsivonen.iki.fi/feed/atom/' />
-      <outline htmlUrl='http://blog.mozilla.org/bjacob' text='Benoit Jacob' title='Benoit Jacob' type='rss' xmlUrl='http://blog.mozilla.org/bjacob/feed/' />
-      <outline htmlUrl='https://www.paciellogroup.com' text='The Paciello Group Blog' title='The Paciello Group Blog' type='rss' xmlUrl='http://blog.paciellogroup.com/feed/' />
-      <outline htmlUrl='https://www.w3.org/blog' text='W3C Blog' title='W3C Blog' type='rss' xmlUrl='http://www.w3.org/blog/feed/' />
-      <outline htmlUrl='https://www.w3.org/blog/CSS' text='CSS Working Group Blog' title='CSS Working Group Blog' type='rss' xmlUrl='http://www.w3.org/blog/CSS/feed/atom/' />
-      <outline htmlUrl='https://www.webkit.org/blog' text="Surfin' Safari" title="Surfin' Safari" type='rss' xmlUrl='https://www.webkit.org/blog/feed/atom/' />
+    <outline text="frontend-standards+browsers" title="frontend-standards+browsers">
+      <outline text="Chromium Blog" title="Chromium Blog" type="rss" xmlUrl="http://blog.chromium.org/feeds/posts/default" htmlUrl="http://blog.chromium.org/"/>
+      <outline text="The HTML5 test" title="The HTML5 test" type="rss" xmlUrl="http://blog.html5test.com/rss" htmlUrl="http://blog.html5test.com/"/>
+      <outline text="Opera Desktop" title="Opera Desktop" type="rss" xmlUrl="http://blogs.opera.com/desktop/feed/" htmlUrl="http://blogs.opera.com/desktop"/>
+      <outline text="Opera Mobile" title="Opera Mobile" type="rss" xmlUrl="http://blogs.opera.com/mobile/feed/" htmlUrl="http://blogs.opera.com/mobile"/>
+      <outline text="IEBlog" title="IEBlog" type="rss" xmlUrl="http://blogs.msdn.com/b/ie/atom.aspx" htmlUrl="http://blogs.msdn.com/b/ie/"/>
+      <outline text="JavaScript" title="JavaScript" type="rss" xmlUrl="https://blog.mozilla.org/javascript/feed/" htmlUrl="https://blog.mozilla.org/javascript"/>
+      <outline text="Brendan Eich" title="Brendan Eich" type="rss" xmlUrl="http://brendaneich.com/feed/" htmlUrl="http://brendaneich.com/"/>
+      <outline text="Can I Use updates" title="Can I Use updates" type="rss" xmlUrl="http://feeds.feedburner.com/WhenCanIUse" htmlUrl="http://caniuse.com/feed.php"/>
+      <outline text="Google Chrome Blog" title="Google Chrome Blog" type="rss" xmlUrl="http://feeds2.feedburner.com/blogspot/Egta" htmlUrl="http://chrome.blogspot.com/"/>
+      <outline text="Mozilla Hacks" title="Mozilla Hacks" type="rss" xmlUrl="http://hacks.mozilla.org/feed/" htmlUrl="https://hacks.mozilla.org/"/>
+      <outline text="Jatinder S Mann" title="Jatinder S Mann" type="rss" xmlUrl="http://jatindersmann.com/feed/" htmlUrl="http://jatindersmann.com/"/>
+      <outline text="mraleph" title="mraleph" type="rss" xmlUrl="http://mrale.ph/atom.xml" htmlUrl="http://mrale.ph/"/>
+      <outline text="Tech Notes" title="Tech Notes" type="rss" xmlUrl="http://neugierig.org/software/blog/atom.xml" htmlUrl="http://neugierig.org/software/blog/"/>
+      <outline text="Peter Beverloo" title="Peter Beverloo" type="rss" xmlUrl="http://peter.sh/feed/" htmlUrl="http://peter.sh/"/>
+      <outline text="Planet WebKit" title="Planet WebKit" type="rss" xmlUrl="http://planet.webkit.org/atom.xml" htmlUrl="http://planet.webkit.org/"/>
+      <outline text="Robert O'Callahan" title="Robert O'Callahan" type="rss" xmlUrl="http://robert.ocallahan.org/feeds/posts/default" htmlUrl="http://robert.ocallahan.org/"/>
+      <outline text="Tavmjong Bah's Blog" title="Tavmjong Bah's Blog" type="rss" xmlUrl="http://tavmjong.free.fr/blog/?feed=rss2" htmlUrl="http://tavmjong.free.fr/blog"/>
+      <outline text="Web Browsers News and Reviews" title="Web Browsers News and Reviews" type="rss" xmlUrl="http://feeds.feedburner.com/FavoriteBrowser" htmlUrl="http://www.favbrowser.com/"/>
+      <outline text="<Glazblog/>" title="<Glazblog/>" type="rss" xmlUrl="http://www.glazman.org/weblog/dotclear/index.php?feed/rss2" htmlUrl="http://www.glazman.org/weblog/dotclear/index.php?"/>
+      <outline text="Tab Atkins" title="Tab Atkins" type="rss" xmlUrl="http://www.xanthir.com/blog/atom/" htmlUrl="http://www.xanthir.com/blog/"/>
+      <outline text="Anne’s Blog" title="Anne’s Blog" type="rss" xmlUrl="http://annevankesteren.nl/feeds/weblog" htmlUrl="https://annevankesteren.nl/"/>
+      <outline text="Opera Labs" title="Opera Labs" type="rss" xmlUrl="http://dev.opera.com/feeds/rss/articles" htmlUrl="https://dev.opera.com/"/>
+      <outline text="Henri Sivonen’s pages" title="Henri Sivonen’s pages" type="rss" xmlUrl="http://hsivonen.iki.fi/feed/atom/" htmlUrl="http://hsivonen.iki.fi/"/>
+      <outline text="Benoit Jacob" title="Benoit Jacob" type="rss" xmlUrl="http://blog.mozilla.org/bjacob/feed/" htmlUrl="http://blog.mozilla.org/bjacob"/>
+      <outline text="The Paciello Group Blog" title="The Paciello Group Blog" type="rss" xmlUrl="http://blog.paciellogroup.com/feed/" htmlUrl="http://www.paciellogroup.com/"/>
+      <outline text="W3C Blog" title="W3C Blog" type="rss" xmlUrl="http://www.w3.org/blog/feed/" htmlUrl="http://www.w3.org/blog"/>
+      <outline text="CSS Working Group Blog" title="CSS Working Group Blog" type="rss" xmlUrl="http://www.w3.org/blog/CSS/feed/atom/" htmlUrl="http://www.w3.org/blog/CSS"/>
+      <outline text="Surfin' Safari" title="Surfin' Safari" type="rss" xmlUrl="https://www.webkit.org/blog/feed/atom/" htmlUrl="https://www.webkit.org/blog"/>
     </outline>
   </body>
 </opml>


### PR DESCRIPTION
The file is 2 years old so several subscriptions now no longer exist.

This is always my starting point when re-setting up an RSS reader (or when recommending to a new dev what they should be reading).

Format changes a lot as I imported this into my RSS reader and removed the dead ones before re-exporting. 

Would be happy to keep this up to date and add some more if desired?